### PR TITLE
ub.php: Strict values

### DIFF
--- a/ub.php
+++ b/ub.php
@@ -11,7 +11,7 @@ var _ub = _ub || {};
 <?php endif; ?>
 
 <?php if( !empty($_GET['maxWidth']) ): ?>
-	_ub.maxWidth = '<?php echo urlencode($_GET['maxWidth']); ?>';
+	_ub.maxWidth = '<?php echo intval($_GET['maxWidth']); ?>';
 <?php endif; ?>
 
 <?php if( !empty($_GET['placeholder']) ): ?>
@@ -19,7 +19,7 @@ var _ub = _ub || {};
 <?php endif; ?>
 
 <?php if( !empty($_GET['showBrick']) ): ?>
-  _ub.showBrick = '<?php echo rawurlencode($_GET['showBrick']); ?>';
+  _ub.showBrick = 1;
 <?php endif; ?>
 
 (function(){


### PR DESCRIPTION
Changes in this commit:
 * maxWidth will only work with pixels and must therefore be an integer, so intval()
 * showBrick is either off or on and the JavaScript expects the value 1, so use 1

Other items to consider:
 * line 3 allows _ub to already exist and modifies the existing object, perhaps it should always start as empty, unless we're going to allow people to initialize _ub in their own JavaScript instead of through ub.php GET parameters.
 * color passes through a string of their choice. We already limit the set of choices in the JavaScript, so maybe we should limit the color here too.
 * given that we have https, we should consider always serving the content over https. This should not break http websites as it is only additional content, not the main page content.